### PR TITLE
(upd) Added array type analyzing.

### DIFF
--- a/Objects/ObjectFetcherService.php
+++ b/Objects/ObjectFetcherService.php
@@ -392,11 +392,14 @@ class ObjectFetcherService
             case self::TYPE_RAW:
                 $newValue = $value;
                 break;
+            case self::TYPE_ARRAY:
+                $newValue = $this->fetch($type, $value, $profiles, $includeDefaultProfile);
+                break;
             default:
                 if (!class_exists($type)) {
                     throw new TypeConversionException("Unknown type '$type'");
                 }
-                $newValue = $this->fetch($type, $value, $profiles, $includeDefaultProfile);
+                $newValue = $value;
                 break;
         }
 


### PR DESCRIPTION
I think this needs to be added for empty arrays, and also for prevent exception if $value in default condition is not array.